### PR TITLE
feat(ST-39): add create classroom form modal

### DIFF
--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.schema.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.schema.ts
@@ -1,0 +1,11 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+export const createClassroomSchema = z.object({
+  title: z.string().trim().min(1, "Title is required"),
+  subject: z.string().trim().min(1, "Subject is required"),
+  classTime: z.string().trim().min(1, "Class time is required"),
+  days: z.array(z.string().trim()).nonempty("At least one day is required"),
+});
+
+export const createClassroomFormResolver = zodResolver(createClassroomSchema);

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.types.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.types.ts
@@ -1,0 +1,6 @@
+export type TCreateClassroomFormData = {
+  title: string;
+  subject: string;
+  classTime: string;
+  days: Array<string>;
+};

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.tsx
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.tsx
@@ -1,0 +1,108 @@
+import React from "react";
+
+import { Button, Flex, Modal, MultiSelect, Select, TextInput, Title } from "@mantine/core";
+import { TimeInput } from "@mantine/dates";
+import { Controller, useForm } from "react-hook-form";
+
+import { SUBJECTS } from "@/modules/Register/components/TeacherRegistrationForm/TeacherRegistrationForm.constants";
+
+import useClassroomCreation from "../../hooks/useClassroomCreation";
+import { createClassroomFormResolver } from "./ClassroomCreatingForm.schema";
+import { TCreateClassroomFormData } from "./ClassroomCreatingForm.types";
+import { ICreateClassroomModalProps } from "./ClassroomCreatingModal.types";
+
+const ClassroomCreatingModal = ({ opened, close }: ICreateClassroomModalProps) => {
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TCreateClassroomFormData>({
+    resolver: createClassroomFormResolver,
+    mode: "onSubmit",
+  });
+
+  const { onSubmit } = useClassroomCreation();
+
+  return (
+    <>
+      <Modal opened={opened} onClose={close} centered>
+        <Title c={"green"} tt={"uppercase"} size={"lg"} mb={12}>
+          Create a classroom
+        </Title>
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Flex direction={"column"} gap={14}>
+            <Controller
+              name="title"
+              control={control}
+              render={({ field }) => (
+                <TextInput
+                  {...field}
+                  label="Title"
+                  placeholder="Enter classroom title"
+                  styles={{ label: { color: "green" } }}
+                  required
+                  error={errors.title?.message}
+                />
+              )}
+            />
+            <Controller
+              name="subject"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  {...field}
+                  label="Subject"
+                  placeholder="Enter subject"
+                  data={SUBJECTS}
+                  styles={{ label: { color: "green" } }}
+                  required
+                  error={errors.subject?.message}
+                />
+              )}
+            />
+            <Controller
+              name="classTime"
+              control={control}
+              render={({ field }) => (
+                <TimeInput
+                  {...field}
+                  label="Class Time"
+                  placeholder="Select class time"
+                  styles={{ label: { color: "green" } }}
+                  required
+                  error={errors.classTime?.message}
+                />
+              )}
+            />
+            <Controller
+              name="days"
+              control={control}
+              render={({ field }) => (
+                <MultiSelect
+                  {...field}
+                  label="Days"
+                  placeholder="Select days"
+                  styles={{ label: { color: "green" } }}
+                  data={["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]}
+                  required
+                  error={errors.days?.message}
+                />
+              )}
+            />
+            <Flex justify={"end"} align={"center"} gap={12} mb={10}>
+              <Button bg={"green"} onClick={() => reset()}>
+                Cancel
+              </Button>
+              <Button bg={"green"} type="submit">
+                Create
+              </Button>
+            </Flex>
+          </Flex>
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+export default ClassroomCreatingModal;

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types.ts
@@ -1,0 +1,4 @@
+export interface ICreateClassroomModalProps {
+  opened: boolean;
+  close: () => void;
+}

--- a/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.tsx
+++ b/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.tsx
@@ -6,13 +6,19 @@ import { authenticatedUserSelector } from "@/shared/redux/reducers/user.reducer"
 import { ERole } from "@/shared/typedefs";
 
 import classes from "./ClassroomContainer.module.css";
+import { IClassroomContainerProps } from "./ClassroomContainer.types";
 
-const ClassroomContainer = () => {
+const ClassroomContainer = ({ open }: IClassroomContainerProps) => {
   const user = useAppSelector(authenticatedUserSelector);
   return (
     <Box mih={"91vh"} pos={"relative"}>
       {user?.claim === ERole.TEACHER ? (
-        <Button bg={"#011733"} leftIcon={<FaPlus />} className={classes["content-position"]}>
+        <Button
+          bg={"#011733"}
+          leftIcon={<FaPlus />}
+          className={classes["content-position"]}
+          onClick={open}
+        >
           Create a classroom
         </Button>
       ) : (

--- a/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.types.ts
+++ b/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.types.ts
@@ -1,0 +1,3 @@
+export interface IClassroomContainerProps {
+  open: () => void;
+}

--- a/modules/UserDashboard/containers/DashboardContainer.tsx
+++ b/modules/UserDashboard/containers/DashboardContainer.tsx
@@ -1,14 +1,22 @@
 import React from "react";
 
+import { useDisclosure } from "@mantine/hooks";
+
 import NavigationBar from "@/modules/components/Navbar/NavigationBar";
 
 import ClassroomContainer from "./ClassroomContainer/ClassroomContainer";
+import ClassroomCreatingModal from "../components/ClassroomCreatingModal/ClassroomCreatingModal";
 
-const DashboardContainer = () => (
-  <>
-    <NavigationBar />
-    <ClassroomContainer />
-  </>
-);
+const DashboardContainer = () => {
+  const [opened, { open, close }] = useDisclosure(false);
+
+  return (
+    <>
+      <NavigationBar open={open} />
+      <ClassroomContainer open={open} />
+      <ClassroomCreatingModal opened={opened} close={close} />
+    </>
+  );
+};
 
 export default DashboardContainer;

--- a/modules/UserDashboard/hooks/useClassroomCreation.ts
+++ b/modules/UserDashboard/hooks/useClassroomCreation.ts
@@ -1,0 +1,11 @@
+import { TCreateClassroomFormData } from "../components/ClassroomCreatingModal/ClassroomCreatingForm.types";
+
+const useClassroomCreation = () => {
+  const onSubmit = (data: TCreateClassroomFormData) => {
+    // will add api call here
+    console.log(data);
+  };
+  return { onSubmit };
+};
+
+export default useClassroomCreation;

--- a/modules/components/Navbar/NavigationBar.tsx
+++ b/modules/components/Navbar/NavigationBar.tsx
@@ -8,8 +8,9 @@ import { authenticatedUserSelector } from "@/shared/redux/reducers/user.reducer"
 import { ERole } from "@/shared/typedefs";
 
 import classes from "./NavigationBar.module.css";
+import { INavigationBarProps } from "./NavigationBar.types";
 
-const NavigationBar = () => {
+const NavigationBar = ({ open }: INavigationBarProps) => {
   const user = useAppSelector(authenticatedUserSelector);
 
   return (
@@ -17,7 +18,7 @@ const NavigationBar = () => {
       <Text>Superteacher</Text>
       <Flex justify={"center"} align={"center"} gap={15}>
         <Text className={classes["dashboard"]}>Dashboard</Text>
-        {user?.claim === ERole.TEACHER && <FaPlus />}
+        {user?.claim === ERole.TEACHER ? <FaPlus onClick={open} /> : null}
         <Button variant="outline" c={"white"} sx={{ borderColor: "white" }}>
           {user?.firstName}
         </Button>

--- a/modules/components/Navbar/NavigationBar.types.ts
+++ b/modules/components/Navbar/NavigationBar.types.ts
@@ -1,0 +1,3 @@
+export interface INavigationBarProps {
+  open: () => void;
+}


### PR DESCRIPTION
## Description of Change

- Added ClassroomCreationModal component
- Developed the form modal as the view template
- Added modal disclosure hook inside dashboard container
- Used zod + react hook form validation

## Associated Ticket Link(s)

- https://trello.com/c/0RUwLfyv

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings
Website view:
<img width="1435" alt="Screen Shot 2024-09-02 at 9 07 53 PM" src="https://github.com/user-attachments/assets/3cfec91f-e0e1-403e-a66b-27fcddf32d30">

Tablet View:
<img width="430" alt="Screen Shot 2024-09-04 at 7 04 25 PM" src="https://github.com/user-attachments/assets/fe7f1063-e69f-4587-9886-a8935e5fcb77">

Mobile View:
<img width="376" alt="Screen Shot 2024-09-04 at 7 03 47 PM" src="https://github.com/user-attachments/assets/e92723fa-b472-4440-8c20-bee027f31cd6">

