### PR TITLE
feat(ST-61): integrate create classroom api with form submit

### DIFF
--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.helper.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.helper.ts
@@ -1,0 +1,11 @@
+export const convertTimeToDate = (time: string) => {
+  const [hoursStr, minutesStr] = time.split(":");
+
+  const hours = Number(hoursStr) || 0;
+  const minutes = Number(minutesStr) || 0;
+
+  const classTimeDate = new Date();
+  classTimeDate.setHours(hours, minutes, 0, 0);
+
+  return classTimeDate;
+};

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.types.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingForm.types.ts
@@ -1,6 +1,0 @@
-export type TCreateClassroomFormData = {
-  title: string;
-  subject: string;
-  classTime: string;
-  days: Array<string>;
-};

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.tsx
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.tsx
@@ -8,8 +8,10 @@ import { SUBJECTS } from "@/modules/Register/components/TeacherRegistrationForm/
 
 import useClassroomCreation from "../../hooks/useClassroomCreation";
 import { createClassroomFormResolver } from "./ClassroomCreatingForm.schema";
-import { TCreateClassroomFormData } from "./ClassroomCreatingForm.types";
-import { ICreateClassroomModalProps } from "./ClassroomCreatingModal.types";
+import {
+  ICreateClassroomModalProps,
+  TCreateClassroomFormData,
+} from "./ClassroomCreatingModal.types";
 
 const ClassroomCreatingModal = ({ opened, close }: ICreateClassroomModalProps) => {
   const {

--- a/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types.ts
+++ b/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types.ts
@@ -2,3 +2,17 @@ export interface ICreateClassroomModalProps {
   opened: boolean;
   close: () => void;
 }
+
+export type TCreateClassroomFormData = {
+  title: string;
+  subject: string;
+  classTime: string;
+  days: Array<string>;
+};
+
+export type TClassroomDetailsDto = {
+  title: string;
+  subject: string;
+  classTime: Date;
+  days: Array<string>;
+};

--- a/modules/UserDashboard/hooks/useClassroomCreation.ts
+++ b/modules/UserDashboard/hooks/useClassroomCreation.ts
@@ -1,9 +1,44 @@
-import { TCreateClassroomFormData } from "../components/ClassroomCreatingModal/ClassroomCreatingForm.types";
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useCreateClassroomMutation } from "@/shared/redux/rtk-apis/classrooms/classrooms.api";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { convertTimeToDate } from "../components/ClassroomCreatingModal/ClassroomCreatingForm.helper";
+import {
+  TClassroomDetailsDto,
+  TCreateClassroomFormData,
+} from "../components/ClassroomCreatingModal/ClassroomCreatingModal.types";
 
 const useClassroomCreation = () => {
-  const onSubmit = (data: TCreateClassroomFormData) => {
-    // will add api call here
-    console.log(data);
+  const [createClassroom] = useCreateClassroomMutation();
+
+  const onSubmit = async (data: TCreateClassroomFormData) => {
+    const classTimeDate = convertTimeToDate(data.classTime);
+
+    const newClassroom: TClassroomDetailsDto = { ...data, classTime: classTimeDate };
+
+    try {
+      const res = await createClassroom(newClassroom).unwrap();
+
+      if (res) {
+        showNotification({
+          title: "Success",
+          message: "Classroom Created Successfully",
+          autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+          color: "green",
+        });
+      }
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
   };
   return { onSubmit };
 };

--- a/shared/redux/rtk-apis/classrooms/classrooms.api.ts
+++ b/shared/redux/rtk-apis/classrooms/classrooms.api.ts
@@ -1,0 +1,19 @@
+import { TClassroomDetailsDto } from "@/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types";
+
+import projectApi from "../api.config";
+import { TClassroomApiResponse } from "./classrooms.types";
+
+const classroomsApi = projectApi.injectEndpoints({
+  endpoints: (builder) => ({
+    createClassroom: builder.mutation<TClassroomApiResponse, TClassroomDetailsDto>({
+      query: (newClassroom) => ({
+        url: "classrooms",
+        method: "POST",
+        body: newClassroom,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+
+export const { useCreateClassroomMutation } = classroomsApi;

--- a/shared/redux/rtk-apis/classrooms/classrooms.types.ts
+++ b/shared/redux/rtk-apis/classrooms/classrooms.types.ts
@@ -1,0 +1,9 @@
+export type TClassroomApiResponse = {
+  id: number;
+  createdAt: string;
+  updatedAt: string;
+  title: string;
+  subject: string;
+  days: Array<string>;
+  classTime: Date;
+};


### PR DESCRIPTION
## Description of Change

- Added a folder called “classrooms” under rtk-apis folder
- Added a file called a classrooms.api.ts and created a classroomsApi
- Added a mutation called createClassroom
- Called this api from createClassroom hooks inside on submit function
- Added notifications for success and errors

## Associated Ticket Link(s)

- https://trello.com/c/fvst5cTf

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/ac9cb60e-05d0-4d70-a009-f0b2639cd98b

