### PR TITLE
feat(ST-54): integrate enroll and remove student api in classroom

### DIFF
--- a/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentForm.schema.ts
+++ b/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentForm.schema.ts
@@ -1,0 +1,8 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const EnrollStudentSchema = z.object({
+  student: z.string().min(1, "You must select a student name"),
+});
+
+export const EnrollStudentSchemaResolver = zodResolver(EnrollStudentSchema);

--- a/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentForm.types.ts
+++ b/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentForm.types.ts
@@ -1,0 +1,9 @@
+export type TEnrollStudentForm = {
+  student: string;
+};
+
+export type TEnrollStudentModalFormProps = {
+  opened: boolean;
+  close: () => void;
+  classroomId: string;
+};

--- a/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentModalForm.tsx
+++ b/modules/Classroom/components/EnrollStudentModalForm/EnrollStudentModalForm.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from "react";
+
+import { Button, Flex, Modal, Title, Select } from "@mantine/core";
+
+import useEnrollmentApiCall from "../../hooks/useEnrollmentApiCall";
+import useGetStudentsToEnroll from "../../hooks/useGetStudentsToEnroll";
+import { TEnrollStudentModalFormProps } from "./EnrollStudentForm.types";
+
+const EnrollStudentModalForm = ({ opened, close, classroomId }: TEnrollStudentModalFormProps) => {
+  const [selectedStudent, setSelectedStudent] = useState<string | null>(null);
+
+  const { students } = useGetStudentsToEnroll(classroomId);
+  const { addStudent } = useEnrollmentApiCall();
+
+  const handleSubmit = () => {
+    if (selectedStudent) {
+      console.log(selectedStudent);
+      addStudent(Number(classroomId), Number(selectedStudent));
+      close();
+    }
+  };
+
+  return (
+    <Modal opened={opened} onClose={close} centered>
+      <Title sx={{ color: "green" }} tt="uppercase" size="lg" mb={24}>
+        Enroll a Student
+      </Title>
+      <Select
+        name="student"
+        label="Type a name"
+        placeholder="Pick student"
+        data={students}
+        value={selectedStudent}
+        onChange={setSelectedStudent}
+        styles={{ label: { color: "green" } }}
+        dropdownPosition="bottom"
+        withinPortal
+        required
+      />
+
+      <Flex justify="end" align="center" gap={12} mt={48}>
+        <Button variant="outline" onClick={close}>
+          Cancel
+        </Button>
+        <Button
+          type="submit"
+          variant="filled"
+          sx={{ backgroundColor: "green" }}
+          onClick={handleSubmit}
+        >
+          Create
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default EnrollStudentModalForm;

--- a/modules/Classroom/components/RemoveConfirmationModal/RemoveConfirmationModal.tsx
+++ b/modules/Classroom/components/RemoveConfirmationModal/RemoveConfirmationModal.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import { Box, Button, Flex, Modal, Title } from "@mantine/core";
+
+import useEnrollmentApiCall from "../../hooks/useEnrollmentApiCall";
+import { TRemoveConfirmationModalProps } from "./RemoveConfirmationModal.types";
+
+const RemoveConfirmationModal = ({
+  opened,
+  close,
+  classroomId,
+  student,
+  setStudentToRemove,
+}: TRemoveConfirmationModalProps) => {
+  const { removeStudent } = useEnrollmentApiCall();
+  const handleDelete = () => {
+    if (student) {
+      removeStudent(classroomId, student.id);
+      setStudentToRemove(null);
+    }
+    close();
+  };
+
+  return (
+    <Modal opened={opened} onClose={close} centered>
+      <Flex direction={"column"} justify={"center"} align={"center"}>
+        <Box w={"80%"}>
+          <Title sx={{ color: "green" }} tt="uppercase" size="lg" mb={24}>
+            {`Are you sure you want to remove ${student && student.user?.firstName} ${student && student.user?.lastName} from the classroom?`}
+          </Title>
+
+          <Flex justify="end" align="center" gap={12} mt={48} mb={32}>
+            <Button variant="filled" sx={{ backgroundColor: "#80147AFF" }} onClick={close}>
+              Cancel
+            </Button>
+            <Button variant="filled" sx={{ backgroundColor: "#80147AFF" }} onClick={handleDelete}>
+              Confirm
+            </Button>
+          </Flex>
+        </Box>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default RemoveConfirmationModal;

--- a/modules/Classroom/components/RemoveConfirmationModal/RemoveConfirmationModal.types.ts
+++ b/modules/Classroom/components/RemoveConfirmationModal/RemoveConfirmationModal.types.ts
@@ -1,0 +1,9 @@
+import { TStudent } from "@/shared/redux/rtk-apis/users/users.types";
+
+export type TRemoveConfirmationModalProps = {
+  opened: boolean;
+  close: () => void;
+  classroomId: number;
+  student: TStudent | null;
+  setStudentToRemove: (value: TStudent | null) => void;
+};

--- a/modules/Classroom/components/Students/Students.tsx
+++ b/modules/Classroom/components/Students/Students.tsx
@@ -1,15 +1,29 @@
-import React from "react";
+import React, { useState } from "react";
 
 import { Flex, Text, Title } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 import { FaRegPlusSquare, FaRegTrashAlt } from "react-icons/fa";
 
 import { useAppSelector } from "@/shared/redux/hooks";
 import { authenticatedUserSelector } from "@/shared/redux/reducers/user.reducer";
+import { TStudent } from "@/shared/redux/rtk-apis/users/users.types";
+import { ERole } from "@/shared/typedefs";
 
+import EnrollStudentModalForm from "../EnrollStudentModalForm/EnrollStudentModalForm";
+import RemoveConfirmationModal from "../RemoveConfirmationModal/RemoveConfirmationModal";
 import { IStudentsProps } from "./Students.types";
 
-const Students = ({ students }: IStudentsProps) => {
-  const { email } = useAppSelector(authenticatedUserSelector);
+const Students = ({ students, classroomId }: IStudentsProps) => {
+  const { email, claim } = useAppSelector(authenticatedUserSelector);
+
+  const [enrollOpened, { open: openEnrollModal, close: closeEnrollModal }] = useDisclosure(false);
+  const [removeOpened, { open: openRemoveModal, close: closeRemoveModal }] = useDisclosure(false);
+  const [studentToRemove, setStudentToRemove] = useState<TStudent | null>(null);
+
+  const handleRemoveStudent = (student: TStudent) => {
+    setStudentToRemove(student);
+    openRemoveModal();
+  };
 
   return (
     <>
@@ -22,7 +36,9 @@ const Students = ({ students }: IStudentsProps) => {
         pb={8}
       >
         <Title order={3}>Students</Title>
-        <FaRegPlusSquare color="green" />
+        {claim === ERole.TEACHER ? (
+          <FaRegPlusSquare color="green" onClick={openEnrollModal} />
+        ) : null}
       </Flex>
       {students?.map((student) => (
         <Flex key={student.id} justify={"space-between"}>
@@ -34,10 +50,24 @@ const Students = ({ students }: IStudentsProps) => {
             <Text fz={"sm"} mr={12}>
               {student.user?.email}{" "}
             </Text>
-            <FaRegTrashAlt color="purple" />
+            {claim === ERole.TEACHER ? (
+              <FaRegTrashAlt color="purple" onClick={() => handleRemoveStudent(student)} />
+            ) : null}
           </Flex>
+          <RemoveConfirmationModal
+            opened={removeOpened}
+            close={closeRemoveModal}
+            classroomId={Number(classroomId)}
+            student={studentToRemove}
+            setStudentToRemove={setStudentToRemove}
+          />
         </Flex>
       ))}
+      <EnrollStudentModalForm
+        close={closeEnrollModal}
+        opened={enrollOpened}
+        classroomId={classroomId}
+      />
     </>
   );
 };

--- a/modules/Classroom/components/Students/Students.types.ts
+++ b/modules/Classroom/components/Students/Students.types.ts
@@ -2,4 +2,5 @@ import { TStudent } from "@/shared/redux/rtk-apis/users/users.types";
 
 export interface IStudentsProps {
   students: TStudent[] | undefined;
+  classroomId: string;
 }

--- a/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
+++ b/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
@@ -4,11 +4,9 @@ import { useRouter } from "next/router";
 
 import { Tabs, Title } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
-import { showNotification } from "@mantine/notifications";
 
 import NavigationBar from "@/modules/components/Navbar/NavigationBar";
 import ClassroomCreatingModal from "@/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal";
-import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
 import {
   useGetClassroomByIdQuery,
   useGetEnrolledStudentsQuery,
@@ -35,14 +33,7 @@ const ClassroomDetailsContainer = () => {
     useGetEnrolledStudentsQuery(classroomId as string);
 
   useEffect(() => {
-    if (isClassroomFetchError || isEnrolledStudentFetchError) {
-      showNotification({
-        title: "Error",
-        message: "Error Fetching Data!",
-        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
-        color: "red",
-      });
-    } else {
+    if (!isClassroomFetchError && !isEnrolledStudentFetchError) {
       setClassroom(fetchedClassroom);
       setEnrolledStudents(fetchedEnrolledStudents);
     }
@@ -90,7 +81,7 @@ const ClassroomDetailsContainer = () => {
 
         <Tabs.Panel value="people">
           <Teacher teacher={classroom?.teacher} />
-          <Students students={enrolledStudents} />
+          <Students students={enrolledStudents} classroomId={classroomId as string} />
         </Tabs.Panel>
       </Tabs>
     </>

--- a/modules/Classroom/hooks/useEnrollmentApiCall.ts
+++ b/modules/Classroom/hooks/useEnrollmentApiCall.ts
@@ -1,0 +1,58 @@
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import {
+  useEnrollStudentMutation,
+  useRemoveStudentMutation,
+} from "@/shared/redux/rtk-apis/classrooms/classrooms.api";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+const useEnrollmentApiCall = () => {
+  const [enrollStudent] = useEnrollStudentMutation();
+  const [deleteStudent] = useRemoveStudentMutation();
+
+  const addStudent = async (classroomId: number, studentId: number) => {
+    try {
+      await enrollStudent({ classroomId, studentId }).unwrap();
+      showNotification({
+        title: "Success",
+        message: "Student Enrolled Successfully",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+
+  const removeStudent = async (classroomId: number, studentId: number) => {
+    try {
+      await deleteStudent({ classroomId, studentId }).unwrap();
+      showNotification({
+        title: "Success",
+        message: "Student Removed Successfully",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+  return { addStudent, removeStudent };
+};
+
+export default useEnrollmentApiCall;

--- a/modules/Classroom/hooks/useGetStudentsToEnroll.ts
+++ b/modules/Classroom/hooks/useGetStudentsToEnroll.ts
@@ -1,0 +1,33 @@
+import { useGetEnrolledStudentsQuery } from "@/shared/redux/rtk-apis/classrooms/classrooms.api";
+import { useGetStudentsQuery } from "@/shared/redux/rtk-apis/users/users.api";
+
+type TStudentSelectOption = {
+  value: string;
+  label: string;
+};
+
+const useGetStudentsToEnroll = (classroomId: string) => {
+  const { data: allUserStudents, isLoading: allUsersStudentsIsLoading } = useGetStudentsQuery();
+  const { data: enrolledStudents, isLoading: enrolledStudentsIsLoading } =
+    useGetEnrolledStudentsQuery(classroomId);
+
+  let students: TStudentSelectOption[] = [];
+
+  if (!allUsersStudentsIsLoading && !enrolledStudentsIsLoading) {
+    if (allUserStudents && enrolledStudents) {
+      const enrolledStudentIds = new Set(enrolledStudents.map((student) => student.id));
+
+      const notEnrolledStudentUser = allUserStudents.filter(
+        (user) => !enrolledStudentIds.has(user.student?.id || -1),
+      );
+
+      students = notEnrolledStudentUser.map((user) => ({
+        value: user.student?.id.toString() || "-1",
+        label: `${user.firstName} ${user.lastName}`,
+      }));
+    }
+  }
+  return { students };
+};
+
+export default useGetStudentsToEnroll;

--- a/modules/Register/hooks/useStudentRegistration.ts
+++ b/modules/Register/hooks/useStudentRegistration.ts
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 
 import { showNotification } from "@mantine/notifications";
 
+import { useSessionContext } from "@/shared/components/wrappers/AppInitializer/AppInitializerContext";
 import {
   ACCESS_TOKEN_LOCAL_STORAGE_KEY,
   NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
@@ -18,6 +19,7 @@ import { TStudentRegistrationFormData } from "../components/StudentRegistrationF
 const useStudentRegistration = () => {
   const [registerStudent] = useRegisterStudentMutation();
   const dispatch = useAppDispatch();
+  const { getMe } = useSessionContext();
   const router = useRouter();
 
   const onSubmit = async (data: TStudentRegistrationFormData) => {
@@ -45,6 +47,7 @@ const useStudentRegistration = () => {
       if (res) {
         setInLocalStorage(ACCESS_TOKEN_LOCAL_STORAGE_KEY, res.accessToken);
         dispatch(setUser(res.user));
+        await getMe().unwrap();
         router.push("/dashboard");
         showNotification({
           title: "Success",

--- a/modules/Register/hooks/useTeacherRegistration.ts
+++ b/modules/Register/hooks/useTeacherRegistration.ts
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 
 import { showNotification } from "@mantine/notifications";
 
+import { useSessionContext } from "@/shared/components/wrappers/AppInitializer/AppInitializerContext";
 import {
   ACCESS_TOKEN_LOCAL_STORAGE_KEY,
   NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
@@ -19,6 +20,7 @@ import { TTeacherRegistrationFormData } from "../components/TeacherRegistrationF
 const useTeacherRegistration = () => {
   const [registerTeacher] = useRegisterTeacherMutation();
   const dispatch = useAppDispatch();
+  const { getMe } = useSessionContext();
   const router = useRouter();
 
   const onSubmit = async (data: TTeacherRegistrationFormData) => {
@@ -42,6 +44,7 @@ const useTeacherRegistration = () => {
       if (res) {
         setInLocalStorage(ACCESS_TOKEN_LOCAL_STORAGE_KEY, res.accessToken);
         dispatch(setUser(res.user));
+        await getMe().unwrap();
         router.push("/dashboard");
         showNotification({
           title: "Success",

--- a/shared/redux/rtk-apis/classrooms/classrooms.api.ts
+++ b/shared/redux/rtk-apis/classrooms/classrooms.api.ts
@@ -3,7 +3,7 @@ import { TApiResponse } from "@/shared/typedefs";
 
 import projectApi from "../api.config";
 import { TStudent } from "../users/users.types";
-import { TClassroom } from "./classrooms.types";
+import { TClassroom, TEnrollInfo, TEnrollMentInfo } from "./classrooms.types";
 
 const classroomsApi = projectApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -34,6 +34,25 @@ const classroomsApi = projectApi.injectEndpoints({
       transformResponse: (response: TApiResponse<TClassroom>) => response.data,
       invalidatesTags: ["Classrooms"],
     }),
+
+    enrollStudent: builder.mutation<TEnrollMentInfo, TEnrollInfo>({
+      query: (enrollmentInfo) => ({
+        url: "classrooms/students",
+        method: "POST",
+        body: enrollmentInfo,
+      }),
+      invalidatesTags: ["EnrolledStudents"],
+      transformResponse: (response: TApiResponse<TEnrollMentInfo>) => response.data,
+    }),
+
+    removeStudent: builder.mutation<TEnrollMentInfo, TEnrollInfo>({
+      query: (removeEnrollmentInfo) => ({
+        url: "classrooms/students",
+        method: "DELETE",
+        body: removeEnrollmentInfo,
+      }),
+      invalidatesTags: ["EnrolledStudents"],
+    }),
   }),
   overrideExisting: false,
 });
@@ -43,4 +62,6 @@ export const {
   useCreateClassroomMutation,
   useGetClassroomByIdQuery,
   useGetEnrolledStudentsQuery,
+  useEnrollStudentMutation,
+  useRemoveStudentMutation,
 } = classroomsApi;

--- a/shared/redux/rtk-apis/classrooms/classrooms.types.ts
+++ b/shared/redux/rtk-apis/classrooms/classrooms.types.ts
@@ -1,4 +1,4 @@
-import { TTeacher } from "../users/users.types";
+import { TStudent, TTeacher } from "../users/users.types";
 
 export type TClassroom = {
   id: number;
@@ -7,4 +7,15 @@ export type TClassroom = {
   classTime: Date;
   days: string[];
   teacher?: TTeacher;
+};
+
+export type TEnrollInfo = {
+  classroomId: number;
+  studentId: number;
+};
+
+export type TEnrollMentInfo = {
+  id: number;
+  classroomId: TClassroom;
+  studentId: TStudent;
 };

--- a/shared/redux/rtk-apis/users/users.api.ts
+++ b/shared/redux/rtk-apis/users/users.api.ts
@@ -3,6 +3,7 @@ import { ICreateStudentDto, ICreateTeacherDto, TApiResponse } from "@/shared/typ
 import projectApi from "../api.config";
 import { TLoginResponse, TTokenizedUser } from "../auth/auth.types";
 import { TUser } from "./users.types";
+import { TUser } from "./users.types";
 
 const usersApi = projectApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -12,7 +13,7 @@ const usersApi = projectApi.injectEndpoints({
     }),
 
     getStudents: builder.query<TUser[], void>({
-      query: () => "students",
+      query: () => "users/students",
       transformResponse: (response: TApiResponse<TUser[]>) => response.data,
     }),
 
@@ -42,5 +43,6 @@ export const {
   useLazyMeQuery,
   useRegisterStudentMutation,
   useRegisterTeacherMutation,
+  useGetStudentsQuery,
   useGetStudentsQuery,
 } = usersApi;

--- a/shared/redux/rtk-apis/users/users.types.ts
+++ b/shared/redux/rtk-apis/users/users.types.ts
@@ -1,5 +1,7 @@
 import { ERole } from "@/shared/typedefs";
 
+import { ERole } from "@/shared/typedefs";
+
 export type TUserProfile = {
   id: number;
   createdAt: string;
@@ -18,7 +20,7 @@ export type TStudent = {
   class: string;
   degreeName: string;
   semesterYear: string;
-  user?: TUser;
+  user: TUser;
 };
 
 export type TTeacher = {


### PR DESCRIPTION
## Description of Change

- Added two rtk mutation for adding and removing students from classroom
- Created a modal containing a dropdown section for choosing student to enroll
- Added a hook that returns students array who are not enrolled in that classroom
- Added another hook that returns two function that should be called to add and remove student classroom apis
- Integrated the modal and add student api with the plus icon and the remove student api with the trash icon .

## Associated Ticket Link(s)

- https://trello.com/c/JHKyXOts

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/f1f4e7fd-2471-4c0f-a969-81a4c99701f4


