### PR TITLE
feat(ST-75): add classroom banner

### DIFF
--- a/modules/Classroom/components/ClassroomBanner/ClassroomBanner.styles.tsx
+++ b/modules/Classroom/components/ClassroomBanner/ClassroomBanner.styles.tsx
@@ -1,0 +1,28 @@
+import { createStyles } from "@mantine/core";
+
+export const useBannerStyles = createStyles((theme) => ({
+  banner: {
+    marginTop: "12px",
+    position: "relative",
+  },
+  bannerTitle: {
+    position: "absolute",
+    padding: "16px",
+    bottom: 0,
+    left: 0,
+    width: "100%",
+  },
+
+  dropdownButton: {
+    position: "absolute",
+    top: 0,
+    right: 0,
+    padding: 10,
+  },
+
+  classDetails: {
+    [theme.fn.largerThan("md")]: {
+      display: "none",
+    },
+  },
+}));

--- a/modules/Classroom/components/ClassroomBanner/ClassroomBanner.tsx
+++ b/modules/Classroom/components/ClassroomBanner/ClassroomBanner.tsx
@@ -1,0 +1,56 @@
+import { ActionIcon, Box, Flex, Image, Menu, SimpleGrid, Text, Title } from "@mantine/core";
+import dayjs from "dayjs";
+import { BsInfoSquare, BsThreeDots } from "react-icons/bs";
+
+import { useBannerStyles } from "./ClassroomBanner.styles";
+import { TClassroomBannerProps } from "./ClassroomBanner.types";
+
+const ClassroomBanner = ({ title, subject, classTime, days }: TClassroomBannerProps) => {
+  const { classes } = useBannerStyles();
+
+  return (
+    <Box className={classes.banner}>
+      <Image src="/bg_classroom.png" alt="Classroom" height={260} radius={"md"} />
+      <Box className={classes.dropdownButton}>
+        <Menu shadow="xl" offset={-1} withArrow arrowPosition="center" position="bottom-end">
+          <Menu.Target>
+            <ActionIcon variant="transparent">
+              <BsThreeDots color="white" />
+            </ActionIcon>
+          </Menu.Target>
+          <Menu.Dropdown>
+            <Menu.Item>Edit</Menu.Item>
+            <Menu.Item color="red">Delete</Menu.Item>
+          </Menu.Dropdown>
+        </Menu>
+      </Box>
+
+      <Box className={classes.bannerTitle}>
+        <Flex justify={"space-between"} align={"center"}>
+          <Title>{title}</Title>
+          <Box className={classes.classDetails}>
+            <Menu shadow="xl" offset={-1} withArrow arrowPosition="center" position="bottom-end">
+              <Menu.Target>
+                <ActionIcon variant="transparent">
+                  <BsInfoSquare color="white" />
+                </ActionIcon>
+              </Menu.Target>
+
+              <Menu.Dropdown>
+                <Menu.Item>
+                  <SimpleGrid p={"xs"}>
+                    <Text size="sm">Subject: {subject}</Text>
+                    <Text size="sm">Class Time: {dayjs(classTime).format("hh:mm:ss A")}</Text>
+                    <Text size="sm">Days: {days.join(", ")}</Text>
+                  </SimpleGrid>
+                </Menu.Item>
+              </Menu.Dropdown>
+            </Menu>
+          </Box>
+        </Flex>
+      </Box>
+    </Box>
+  );
+};
+
+export default ClassroomBanner;

--- a/modules/Classroom/components/ClassroomBanner/ClassroomBanner.types.ts
+++ b/modules/Classroom/components/ClassroomBanner/ClassroomBanner.types.ts
@@ -1,0 +1,6 @@
+export type TClassroomBannerProps = {
+  title: string;
+  subject: string;
+  classTime: Date;
+  days: Array<string>;
+};

--- a/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
+++ b/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 import { useRouter } from "next/router";
 
@@ -7,6 +7,7 @@ import { useDisclosure } from "@mantine/hooks";
 
 import NavigationBar from "@/modules/components/Navbar/NavigationBar";
 import ClassroomCreatingModal from "@/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal";
+import LoadingComponent from "@/shared/components/LoadingComponent";
 import {
   useGetClassroomByIdQuery,
   useGetEnrolledStudentsQuery,
@@ -16,6 +17,7 @@ import { TStudent } from "@/shared/redux/rtk-apis/users/users.types";
 
 import Students from "../../components/Students/Students";
 import Teacher from "../../components/Teacher/Teacher";
+import ClassroomStreamContainer from "../ClassroomStreamContainer/ClassroomStreamContainer";
 
 const ClassroomDetailsContainer = () => {
   const [opened, { open, close }] = useDisclosure(false);
@@ -26,9 +28,12 @@ const ClassroomDetailsContainer = () => {
 
   const classroomId = router.query["id"];
 
-  const { data: fetchedClassroom, isError: isClassroomFetchError } = useGetClassroomByIdQuery(
-    classroomId as string,
-  );
+  const {
+    data: fetchedClassroom,
+    isLoading: isClassroomFetchLoading,
+    isError: isClassroomFetchError,
+  } = useGetClassroomByIdQuery(classroomId as string);
+
   const { data: fetchedEnrolledStudents, isError: isEnrolledStudentFetchError } =
     useGetEnrolledStudentsQuery(classroomId as string);
 
@@ -78,6 +83,14 @@ const ClassroomDetailsContainer = () => {
             </Title>
           </Tabs.Tab>
         </Tabs.List>
+
+        <Tabs.Panel value="stream">
+          {isClassroomFetchLoading || !classroom ? (
+            <LoadingComponent visible={true} />
+          ) : (
+            <ClassroomStreamContainer classroom={classroom} />
+          )}
+        </Tabs.Panel>
 
         <Tabs.Panel value="people">
           <Teacher teacher={classroom?.teacher} />

--- a/modules/Classroom/containers/ClassroomStreamContainer/ClassroomStreamContainer.tsx
+++ b/modules/Classroom/containers/ClassroomStreamContainer/ClassroomStreamContainer.tsx
@@ -1,0 +1,15 @@
+import ClassroomBanner from "../../components/ClassroomBanner/ClassroomBanner";
+import { TClassroomStreamContainerProps } from "./ClassroomStreamContainer.types";
+
+const ClassroomStreamContainer = ({ classroom }: TClassroomStreamContainerProps) => (
+  <>
+    <ClassroomBanner
+      title={classroom.title}
+      subject={classroom.subject}
+      classTime={classroom.classTime}
+      days={classroom.days}
+    />
+  </>
+);
+
+export default ClassroomStreamContainer;

--- a/modules/Classroom/containers/ClassroomStreamContainer/ClassroomStreamContainer.types.ts
+++ b/modules/Classroom/containers/ClassroomStreamContainer/ClassroomStreamContainer.types.ts
@@ -1,0 +1,5 @@
+import { TClassroom } from "@/shared/redux/rtk-apis/classrooms/classrooms.types";
+
+export type TClassroomStreamContainerProps = {
+  classroom: TClassroom;
+};

--- a/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.tsx
+++ b/modules/UserDashboard/containers/ClassroomContainer/ClassroomContainer.tsx
@@ -26,8 +26,6 @@ const ClassroomContainer = ({ open }: IClassroomContainerProps) => {
     }
   }, [data, isSuccess]);
 
-  console.log(data);
-
   return (
     <Box mih={"91vh"} pos={"relative"}>
       {isSuccess && classrooms.length > 0 ? (

--- a/shared/components/SubmitButton/SubmitButton.tsx
+++ b/shared/components/SubmitButton/SubmitButton.tsx
@@ -6,6 +6,7 @@ import { useSubmitButtonStyle } from "./SubmitButton.style";
 
 const SubmitButton = () => {
   const { classes } = useSubmitButtonStyle();
+
   return (
     <Button type="submit" className={classes.submitButton}>
       Submit


### PR DESCRIPTION
## Description of Change

- Added a banner component
- Added edit & delete dropdown menu
- Added classroom details in a dropdown for mobile and tablet

## Associated Ticket Link(s)

- https://trello.com/c/Ji2zj1K1

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings
Web View:
<img width="1434" alt="Screen Shot 2024-09-12 at 3 22 15 PM" src="https://github.com/user-attachments/assets/9000671f-03b5-4155-926a-1dde69c20a69">

Mobile View:
<img width="373" alt="Screen Shot 2024-09-12 at 3 21 55 PM" src="https://github.com/user-attachments/assets/f2ca6917-76f8-4d31-9dbf-7716e3db1cf2">
