### PR TITLE
feat(ST-96): add create exam modal and integrate api

### DIFF
--- a/modules/Classroom/components/ClassworkCreateButton/ClassworkCreateButton.tsx
+++ b/modules/Classroom/components/ClassworkCreateButton/ClassworkCreateButton.tsx
@@ -4,8 +4,9 @@ import { FaBook, FaPlus, FaTimes } from "react-icons/fa";
 import { LuClipboardList, LuFileEdit } from "react-icons/lu";
 
 import { useCreateButtonStyles } from "./ClassworkCreateButton.styles";
+import { TClassworkCreateButtonProps } from "./ClassworkCreateButton.types";
 
-const ClassworkCreateButton = () => {
+const ClassworkCreateButton = ({ openExamModal }: TClassworkCreateButtonProps) => {
   const [opened, { toggle }] = useDisclosure(false);
   const { classes } = useCreateButtonStyles(opened);
 
@@ -19,7 +20,11 @@ const ClassworkCreateButton = () => {
         {opened ? "Close" : "Create"}
       </Button>
 
-      <Button className={classes.classworkButton} leftIcon={<LuClipboardList />}>
+      <Button
+        className={classes.classworkButton}
+        leftIcon={<LuClipboardList />}
+        onClick={openExamModal}
+      >
         Schedule Exam
       </Button>
       <Button className={classes.classworkButton} leftIcon={<LuFileEdit />}>

--- a/modules/Classroom/components/ClassworkCreateButton/ClassworkCreateButton.types.ts
+++ b/modules/Classroom/components/ClassworkCreateButton/ClassworkCreateButton.types.ts
@@ -1,0 +1,3 @@
+export type TClassworkCreateButtonProps = {
+  openExamModal: () => void;
+};

--- a/modules/Classroom/components/CreateExamModal/CreateExamForm.schema.ts
+++ b/modules/Classroom/components/CreateExamModal/CreateExamForm.schema.ts
@@ -1,0 +1,12 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const createExamSchema = z.object({
+  title: z.string().trim().min(1, "Title is required!"),
+  instruction: z.string().trim().min(1, "Instruction is required"),
+  dueDate: z.date().refine((date) => date >= new Date(), {
+    message: "Due date cannot be in the past!",
+  }),
+});
+
+export const createExamSchemaResolver = zodResolver(createExamSchema);

--- a/modules/Classroom/components/CreateExamModal/CreateExamModal.styles.ts
+++ b/modules/Classroom/components/CreateExamModal/CreateExamModal.styles.ts
@@ -1,0 +1,13 @@
+import { createStyles } from "@mantine/core";
+
+export const useExamModalStyles = createStyles((theme) => ({
+  titleText: {
+    textTransform: "uppercase",
+    color: theme.colors.green[6],
+  },
+  input: {
+    label: {
+      color: theme.colors.green[6],
+    },
+  },
+}));

--- a/modules/Classroom/components/CreateExamModal/CreateExamModal.tsx
+++ b/modules/Classroom/components/CreateExamModal/CreateExamModal.tsx
@@ -1,0 +1,97 @@
+import { Button, Flex, Modal, Textarea, TextInput, Title } from "@mantine/core";
+import { DateInput } from "@mantine/dates";
+import { Controller, useForm } from "react-hook-form";
+
+import useCreateExamForm from "../../hooks/useCreateExamForm";
+import { createExamSchemaResolver } from "./CreateExamForm.schema";
+import { useExamModalStyles } from "./CreateExamModal.styles";
+import { TCreateExamModalProps, TCreateExamFormData } from "./CreateExamModal.types";
+
+const CreateExamModal = ({ opened, close, classroomId }: TCreateExamModalProps) => {
+  const { classes } = useExamModalStyles();
+
+  const {
+    control,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<TCreateExamFormData>({
+    resolver: createExamSchemaResolver,
+    mode: "onSubmit",
+  });
+
+  const { onSubmit, isLoading } = useCreateExamForm(classroomId);
+
+  const handleOnSubmit = (data: TCreateExamFormData) => {
+    onSubmit(data);
+    if (!isLoading) {
+      close();
+    }
+  };
+
+  return (
+    <>
+      <Modal opened={opened} onClose={close} centered>
+        <Title className={classes.titleText} order={4}>
+          Schedule Exam
+        </Title>
+        <form onSubmit={handleSubmit(handleOnSubmit)}>
+          <Flex direction={"column"} gap={30} mt={12}>
+            <Controller
+              name="title"
+              control={control}
+              render={({ field }) => (
+                <TextInput
+                  {...field}
+                  label="Title"
+                  placeholder="Enter a title"
+                  className={classes.input}
+                  error={errors.title?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="instruction"
+              control={control}
+              render={({ field }) => (
+                <Textarea
+                  {...field}
+                  label="Instructions"
+                  placeholder="Enter instructions"
+                  className={classes.input}
+                  error={errors.instruction?.message}
+                />
+              )}
+            />
+
+            <Controller
+              name="dueDate"
+              control={control}
+              render={({ field }) => (
+                <DateInput
+                  {...field}
+                  label="Date"
+                  placeholder="Select a date"
+                  className={classes.input}
+                  error={errors.dueDate?.message}
+                />
+              )}
+            />
+
+            <Flex justify={"end"} align={"center"} gap={12} mb={10}>
+              <Button bg={"green"} onClick={() => reset()}>
+                Cancel
+              </Button>
+              <Button loading={isLoading} bg={"green"} type="submit">
+                Schedule
+              </Button>
+            </Flex>
+          </Flex>
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+export default CreateExamModal;

--- a/modules/Classroom/components/CreateExamModal/CreateExamModal.types.ts
+++ b/modules/Classroom/components/CreateExamModal/CreateExamModal.types.ts
@@ -1,0 +1,11 @@
+export type TCreateExamModalProps = {
+  opened: boolean;
+  close: () => void;
+  classroomId: number;
+};
+
+export type TCreateExamFormData = {
+  title: string;
+  instruction: string;
+  dueDate: Date;
+};

--- a/modules/Classroom/containers/ClassroomClassworkContainer/ClassroomClassworkContainer.tsx
+++ b/modules/Classroom/containers/ClassroomClassworkContainer/ClassroomClassworkContainer.tsx
@@ -1,19 +1,24 @@
 import { Box } from "@mantine/core";
+import { useDisclosure } from "@mantine/hooks";
 
 import { useAppSelector } from "@/shared/redux/hooks";
 import { authenticatedUserSelector } from "@/shared/redux/reducers/user.reducer";
 import { ERole } from "@/shared/typedefs";
 
 import ClassworkCreateButton from "../../components/ClassworkCreateButton/ClassworkCreateButton";
+import CreateExamModal from "../../components/CreateExamModal/CreateExamModal";
 import { useClassworkContainerStyles } from "./ClassroomClassworkContainer.styles";
+import { TClassroomClassworkContainerProps } from "./ClassroomClassworkContainer.types";
 
-const ClassroomClassworkContainer = () => {
+const ClassroomClassworkContainer = ({ classroom }: TClassroomClassworkContainerProps) => {
   const { claim } = useAppSelector(authenticatedUserSelector);
   const { classes } = useClassworkContainerStyles();
+  const [examModalOpened, { open: openExamModal, close: closeExamModal }] = useDisclosure(false);
 
   return (
     <Box className={classes.container}>
-      {claim === ERole.TEACHER ? <ClassworkCreateButton /> : null}
+      {claim === ERole.TEACHER ? <ClassworkCreateButton openExamModal={openExamModal} /> : null}
+      <CreateExamModal opened={examModalOpened} close={closeExamModal} classroomId={classroom.id} />
     </Box>
   );
 };

--- a/modules/Classroom/containers/ClassroomClassworkContainer/ClassroomClassworkContainer.types.ts
+++ b/modules/Classroom/containers/ClassroomClassworkContainer/ClassroomClassworkContainer.types.ts
@@ -1,0 +1,5 @@
+import { TClassroom } from "@/shared/redux/rtk-apis/classrooms/classrooms.types";
+
+export type TClassroomClassworkContainerProps = {
+  classroom: TClassroom;
+};

--- a/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
+++ b/modules/Classroom/containers/ClassroomDetailsContainer/ClassroomDetailsContainer.tsx
@@ -94,7 +94,11 @@ const ClassroomDetailsContainer = () => {
         </Tabs.Panel>
 
         <Tabs.Panel value="classwork">
-          <ClassroomClassworkContainer />
+          {isClassroomFetchLoading || !classroom ? (
+            <LoadingComponent visible={true} />
+          ) : (
+            <ClassroomClassworkContainer classroom={classroom} />
+          )}
         </Tabs.Panel>
 
         <Tabs.Panel value="people">

--- a/modules/Classroom/hooks/useCreateExamForm.ts
+++ b/modules/Classroom/hooks/useCreateExamForm.ts
@@ -1,0 +1,44 @@
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useCreateExamMutation } from "@/shared/redux/rtk-apis/exams/exams.api";
+import { TCreateExamDto } from "@/shared/redux/rtk-apis/exams/exams.types";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { TCreateExamFormData } from "../components/CreateExamModal/CreateExamModal.types";
+
+const useCreateExamForm = (classroomId: number) => {
+  const [createExam, { isLoading }] = useCreateExamMutation();
+
+  const onSubmit = async (data: TCreateExamFormData) => {
+    const newExam: TCreateExamDto = {
+      title: data.title,
+      instruction: data.instruction,
+      date: data.dueDate,
+    };
+
+    try {
+      await createExam({ id: classroomId, newExam }).unwrap();
+
+      showNotification({
+        title: "Success",
+        message: "Exam Created Successfully!",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+
+  return { onSubmit, isLoading };
+};
+
+export default useCreateExamForm;

--- a/shared/redux/rtk-apis/api.config.ts
+++ b/shared/redux/rtk-apis/api.config.ts
@@ -5,7 +5,7 @@ import baseQuery from "@/shared/redux/rtk-apis/baseQuery";
 export const projectApi = createApi({
   reducerPath: "projectApi",
   baseQuery,
-  tagTypes: ["Classrooms", "Students", "EnrolledStudents", "ClassroomMessages"],
+  tagTypes: ["Classrooms", "Students", "EnrolledStudents", "ClassroomMessages", "ClassroomExams"],
   endpoints: () => ({}),
 });
 

--- a/shared/redux/rtk-apis/exams/exams.api.ts
+++ b/shared/redux/rtk-apis/exams/exams.api.ts
@@ -1,0 +1,20 @@
+import { TApiResponse } from "@/shared/typedefs";
+
+import projectApi from "../api.config";
+import { TCreateExamDto, TExam } from "./exams.types";
+
+const examsApi = projectApi.injectEndpoints({
+  endpoints: (builder) => ({
+    createExam: builder.mutation<TExam, { id: number; newExam: TCreateExamDto }>({
+      query: ({ id, newExam }) => ({
+        url: `classrooms/${id}/exams`,
+        method: "POST",
+        body: newExam,
+      }),
+      invalidatesTags: (_result, _error, { id }) => [{ type: "ClassroomExams", id: id }],
+      transformResponse: (response: TApiResponse<TExam>) => response.data,
+    }),
+  }),
+});
+
+export const { useCreateExamMutation } = examsApi;

--- a/shared/redux/rtk-apis/exams/exams.types.ts
+++ b/shared/redux/rtk-apis/exams/exams.types.ts
@@ -1,0 +1,13 @@
+export type TExam = {
+  id: number;
+  title: string;
+  instruction: string;
+  date: Date;
+  classroom?: number;
+};
+
+export type TCreateExamDto = {
+  title: string;
+  instruction: string;
+  date: Date;
+};


### PR DESCRIPTION
## Description of Change

- Added a create exam modal component
- Added connection with the button
- Added a rtk mutation for posting exam
- Added a hook to call the api

## Associated Ticket Link(s)

- https://trello.com/c/8Ux8Gnqm

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/4db49dee-db4f-40ca-b501-418c0e6e43a9

