### PR TITLE
feat(ST-94): add assignmets display section and integrate api

### DIFF
--- a/modules/Classroom/components/AssignmentCard/AssignmentCard.styles.ts
+++ b/modules/Classroom/components/AssignmentCard/AssignmentCard.styles.ts
@@ -1,0 +1,51 @@
+import { createStyles } from "@mantine/core";
+import dayjs from "dayjs";
+
+export const useAssignmentCardStyles = createStyles((theme, dueDate: Date) => {
+  const dueDateObject = dayjs(dueDate);
+  const isPastDueDate = dueDateObject.isBefore(dayjs());
+
+  return {
+    card: {
+      background: theme.colors.gray[0],
+      color: theme.colors.dark,
+      padding: 16,
+      borderRadius: 8,
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      height: "100%",
+      gap: 20,
+    },
+
+    icon: {
+      background: theme.colors.gray[3],
+      padding: 6,
+      width: 24,
+      height: 24,
+      borderRadius: "50%",
+      display: "flex",
+      alignItems: "center",
+      textAlign: "center",
+    },
+
+    cardEnd: {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "flex-end",
+      marginTop: "auto",
+    },
+
+    downloadButton: {
+      background: theme.colors.dark[8],
+      "&:hover": {
+        background: theme.colors.dark[4],
+      },
+    },
+
+    dateText: {
+      color: isPastDueDate ? theme.colors.red[9] : theme.colors.dark,
+      marginTop: theme.spacing.xs,
+    },
+  };
+});

--- a/modules/Classroom/components/AssignmentCard/AssignmentCard.tsx
+++ b/modules/Classroom/components/AssignmentCard/AssignmentCard.tsx
@@ -1,0 +1,43 @@
+import { Box, Button, Flex, Text, Title } from "@mantine/core";
+import dayjs from "dayjs";
+import { FaFilePdf } from "react-icons/fa";
+import { LuFileEdit } from "react-icons/lu";
+
+import { EDateFormat } from "@/shared/typedefs";
+
+import { useAssignmentCardStyles } from "./AssignmentCard.styles";
+import { TAssignmentCardProps } from "./AssignmentCard.types";
+
+const AssignmentCard = ({ assignment }: TAssignmentCardProps) => {
+  const { classes } = useAssignmentCardStyles(assignment.dueDate);
+
+  const handleOpenFile = () => {
+    window.open(assignment.fileUrl, "_blank");
+  };
+
+  return (
+    <Box className={classes.card}>
+      <Flex justify={"space-between"}>
+        <Flex align={"center"} gap={8}>
+          <Box className={classes.icon}>{<LuFileEdit />}</Box>
+          <Title order={5}>{assignment.title}</Title>
+        </Flex>
+      </Flex>
+      <Text size={"sm"}>{assignment.description}</Text>
+      <Box className={classes.cardEnd}>
+        <Button
+          className={classes.downloadButton}
+          rightIcon={<FaFilePdf />}
+          onClick={handleOpenFile}
+        >
+          Download
+        </Button>
+        <Text className={classes.dateText}>
+          <strong> Due Date:</strong> {dayjs(assignment.dueDate).format(EDateFormat.SHORT)}
+        </Text>
+      </Box>
+    </Box>
+  );
+};
+
+export default AssignmentCard;

--- a/modules/Classroom/components/AssignmentCard/AssignmentCard.types.ts
+++ b/modules/Classroom/components/AssignmentCard/AssignmentCard.types.ts
@@ -1,0 +1,6 @@
+import { TAssignment } from "@/shared/redux/rtk-apis/assignments/assignments.types";
+
+export type TAssignmentCardProps = {
+  assignment: TAssignment;
+  classroomId: number;
+};

--- a/modules/Classroom/containers/AssignmentsCardContainer/AssignmentsCardContainer.tsx
+++ b/modules/Classroom/containers/AssignmentsCardContainer/AssignmentsCardContainer.tsx
@@ -1,0 +1,32 @@
+import { Text } from "@mantine/core";
+
+import LoadingComponent from "@/shared/components/LoadingComponent";
+import { useGetAssignmentsQuery } from "@/shared/redux/rtk-apis/assignments/assignments.api";
+
+import AssignmentCard from "../../components/AssignmentCard/AssignmentCard";
+import { TAssignmentsCardContainerProps } from "./AssignmentsCardContainer.types";
+
+const AssignmentsCardContainer = ({ classroomId }: TAssignmentsCardContainerProps) => {
+  const { data: fetchedAssignments, isLoading: isAssignmentsLoading } = useGetAssignmentsQuery(
+    classroomId,
+    { skip: !classroomId },
+  );
+
+  if (isAssignmentsLoading) {
+    return <LoadingComponent visible />;
+  }
+
+  if (fetchedAssignments?.length === 0) {
+    return <Text>No resources uploaded</Text>;
+  }
+
+  return (
+    <>
+      {fetchedAssignments?.map((assignment) => (
+        <AssignmentCard key={assignment.id} assignment={assignment} classroomId={classroomId} />
+      ))}
+    </>
+  );
+};
+
+export default AssignmentsCardContainer;

--- a/modules/Classroom/containers/AssignmentsCardContainer/AssignmentsCardContainer.types.ts
+++ b/modules/Classroom/containers/AssignmentsCardContainer/AssignmentsCardContainer.types.ts
@@ -1,0 +1,3 @@
+export type TAssignmentsCardContainerProps = {
+  classroomId: number;
+};

--- a/modules/Classroom/containers/ClassroomResourcesContainer/ClassroomResourcesContainer.tsx
+++ b/modules/Classroom/containers/ClassroomResourcesContainer/ClassroomResourcesContainer.tsx
@@ -6,12 +6,15 @@ import LoadingComponent from "@/shared/components/LoadingComponent";
 import { useGetResourceMaterialsQuery } from "@/shared/redux/rtk-apis/resources/resources.api";
 
 import ResourceMaterialCard from "../../components/ResourceMaterialCard/ResourceMaterialCard";
+import AssignmentsCardContainer from "../AssignmentsCardContainer/AssignmentsCardContainer";
 import { useResourcesStyles } from "./ClassroomResourcesContainer.styles";
 import { TClassroomResourcesContainerProps } from "./ClassroomResourcesContainer.types";
 
 const ClassroomResourcesContainer = ({ classroomId }: TClassroomResourcesContainerProps) => {
   const { classes } = useResourcesStyles();
   const [isMaterialsOpened, { toggle: materialsToggle }] = useDisclosure(false);
+  const [isAssignmentsOpened, { toggle: assignmentsToggle }] = useDisclosure(false);
+
   const { data: fetchedMaterials, isLoading: isMaterialsLoading } = useGetResourceMaterialsQuery(
     classroomId,
     { skip: !classroomId },
@@ -49,6 +52,19 @@ const ClassroomResourcesContainer = ({ classroomId }: TClassroomResourcesContain
               : null}
           </Box>
         )}
+      </Box>
+      <Box>
+        <Flex align={"center"} gap={12} mt={12}>
+          {isAssignmentsOpened ? (
+            <FaAngleDown className={classes.icon} onClick={assignmentsToggle} />
+          ) : (
+            <FaAngleRight className={classes.icon} onClick={assignmentsToggle} />
+          )}
+          <Title order={4}>Assignments</Title>
+        </Flex>
+        <Box className={classes.cardsContainer}>
+          {isAssignmentsOpened ? <AssignmentsCardContainer classroomId={classroomId} /> : null}
+        </Box>
       </Box>
     </>
   );

--- a/shared/redux/rtk-apis/api.config.ts
+++ b/shared/redux/rtk-apis/api.config.ts
@@ -12,6 +12,7 @@ export const projectApi = createApi({
     "ClassroomMessages",
     "ClassroomExams",
     "ClassroomResources",
+    "ClassroomAssignments",
   ],
   endpoints: () => ({}),
 });

--- a/shared/redux/rtk-apis/assignments/assignments.api.ts
+++ b/shared/redux/rtk-apis/assignments/assignments.api.ts
@@ -1,0 +1,16 @@
+import { TApiResponse } from "@/shared/typedefs";
+
+import projectApi from "../api.config";
+import { TAssignment } from "./assignments.types";
+
+const assignmentsApi = projectApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getAssignments: builder.query<TAssignment[], number>({
+      query: (id) => `classrooms/${id}/assignments`,
+      providesTags: (_result, _error, id) => [{ type: "ClassroomAssignments", id }],
+      transformResponse: (response: TApiResponse<TAssignment[]>) => response.data,
+    }),
+  }),
+});
+
+export const { useGetAssignmentsQuery } = assignmentsApi;

--- a/shared/redux/rtk-apis/assignments/assignments.types.ts
+++ b/shared/redux/rtk-apis/assignments/assignments.types.ts
@@ -1,0 +1,8 @@
+export type TAssignment = {
+  id: number;
+  title: string;
+  description: string;
+  fileUrl: string;
+  dueDate: Date;
+  classroom?: number;
+};


### PR DESCRIPTION
## Description of Change

- Added assignment card component
- Added get assignments rtk query inside assignments.api.ts
- Integrated it in resources container
- Rendered assignments

## Associated Ticket Link(s)

- https://trello.com/c/Gt1yGn83

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings
Web view:
<img width="1429" alt="Screen Shot 2024-09-23 at 11 40 46 PM" src="https://github.com/user-attachments/assets/29b391f7-040c-491e-ae03-601dd47cc23f">

Tab view:
<img width="476" alt="Screen Shot 2024-09-23 at 11 41 41 PM" src="https://github.com/user-attachments/assets/ad603adc-5343-4b7b-a9fe-c11debd239d5">

Mobile view:
<img width="312" alt="Screen Shot 2024-09-23 at 11 41 27 PM" src="https://github.com/user-attachments/assets/f0811000-ca93-4b49-ba6a-ca9501a93f17">
