### PR TITLE
feat(ST-132): integrate delete classroom api

### DIFF
--- a/modules/Classroom/components/MeetlinkModal/MeetlinkModal.styles.ts
+++ b/modules/Classroom/components/MeetlinkModal/MeetlinkModal.styles.ts
@@ -1,0 +1,14 @@
+import { createStyles } from "@mantine/core";
+
+export const useMeetlinkModalStyles = createStyles((theme) => ({
+  title: {
+    color: theme.colors.green[7],
+    marginBottom: 20,
+  },
+
+  input: {
+    label: {
+      color: theme.colors.green[6],
+    },
+  },
+}));

--- a/modules/Classroom/components/MeetlinkModal/MeetlinkModal.tsx
+++ b/modules/Classroom/components/MeetlinkModal/MeetlinkModal.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+
+import { Button, Flex, Modal, Text, TextInput, Title } from "@mantine/core";
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useEditClassroomMutation } from "@/shared/redux/rtk-apis/classrooms/classrooms.api";
+import { TEditClassroomDto } from "@/shared/redux/rtk-apis/classrooms/classrooms.types";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { useMeetlinkModalStyles } from "./MeetlinkModal.styles";
+import { TMeetlinkModalProps } from "./MeetlinkModal.types";
+
+const MeetlinkModal = ({ opened, close, classroomId, meetlink }: TMeetlinkModalProps) => {
+  const { classes } = useMeetlinkModalStyles();
+  const [newMeetLink, setNewMeetLink] = useState<string>("");
+  const [validationMessage, setValidationMessage] = useState<string | null>(null);
+
+  const [editClassroom, { isLoading }] = useEditClassroomMutation();
+
+  const handleCancelButton = () => {
+    setNewMeetLink("");
+    setValidationMessage(null);
+    close();
+  };
+
+  const handleAddButton = async () => {
+    if (newMeetLink.trim().length === 0) {
+      return setValidationMessage("Meet Link is required");
+    }
+
+    let formattedLink = newMeetLink.trim();
+    if (!/^https?:\/\//i.test(formattedLink)) {
+      formattedLink = `https://${formattedLink}`;
+    }
+
+    try {
+      new URL(formattedLink);
+    } catch (error) {
+      return setValidationMessage("Please insert a valid URL");
+    }
+
+    const updatedClassroom: TEditClassroomDto = {
+      meetLink: formattedLink,
+    };
+
+    try {
+      const res = await editClassroom({ classroomId, updatedClassroom }).unwrap();
+
+      if (res) {
+        showNotification({
+          title: "Success",
+          message: "Meet Link Added Successfully",
+          autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+          color: "green",
+        });
+      }
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+    setValidationMessage(null);
+    close();
+  };
+
+  return (
+    <Modal opened={opened} onClose={close} centered>
+      <Title className={classes.title} order={4}>
+        {meetlink ? "Edit Meet Link" : "Add Meet Link"}
+      </Title>
+      <TextInput
+        placeholder="Enter a link"
+        label="Meet Link"
+        value={newMeetLink || meetlink}
+        onChange={(e) => setNewMeetLink(e.target.value)}
+        className={classes.input}
+        withAsterisk
+      />
+      <Text size={"xs"} color="red">
+        {validationMessage}
+      </Text>
+      <Flex justify={"end"} align={"center"} gap={12} my={10}>
+        <Button bg={"green"} onClick={handleCancelButton}>
+          Cancel
+        </Button>
+        <Button loading={isLoading} bg={"green"} type="submit" onClick={handleAddButton}>
+          Add
+        </Button>
+      </Flex>
+    </Modal>
+  );
+};
+
+export default MeetlinkModal;

--- a/modules/Classroom/components/MeetlinkModal/MeetlinkModal.types.ts
+++ b/modules/Classroom/components/MeetlinkModal/MeetlinkModal.types.ts
@@ -1,0 +1,6 @@
+export type TMeetlinkModalProps = {
+  opened: boolean;
+  close: () => void;
+  classroomId: number;
+  meetlink?: string;
+};

--- a/shared/redux/rtk-apis/classrooms/classrooms.api.ts
+++ b/shared/redux/rtk-apis/classrooms/classrooms.api.ts
@@ -1,5 +1,5 @@
 import { TClassroomDetailsDto } from "@/modules/UserDashboard/components/ClassroomCreatingModal/ClassroomCreatingModal.types";
-import { TApiResponse } from "@/shared/typedefs";
+import { TApiResponse, TDeleteApiResponse } from "@/shared/typedefs";
 
 import projectApi from "../api.config";
 import { TStudent } from "../users/users.types";
@@ -68,6 +68,14 @@ const classroomsApi = projectApi.injectEndpoints({
       }),
       invalidatesTags: (_result, _error, { classroomId }) => [{ type: "Classrooms", classroomId }],
     }),
+
+    deleteClassroom: builder.mutation<TDeleteApiResponse, number>({
+      query: (classroomId) => ({
+        url: `classrooms/${classroomId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _error, classroomId) => [{ type: "Classrooms", classroomId }],
+    }),
   }),
   overrideExisting: false,
 });
@@ -80,4 +88,5 @@ export const {
   useEnrollStudentMutation,
   useRemoveStudentMutation,
   useEditClassroomMutation,
+  useDeleteClassroomMutation,
 } = classroomsApi;


### PR DESCRIPTION
## Description of Change

- Added a rtk mutation to delete classroom
- Added a delete handler method to delete classroom
- Sent the method to delete confirmation modal
- After successful delete, redirected to dashboard page

## Associated Ticket Link(s)

- https://trello.com/c/sTyCzEj9

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/3cc39946-403f-4b79-bda6-3aa6f57d3600

