### PR TITLE
feat(ST-151): add forget password forms components

### DIFF
--- a/modules/Login/containers/LoginContainer.styles.ts
+++ b/modules/Login/containers/LoginContainer.styles.ts
@@ -1,0 +1,10 @@
+import { createStyles } from "@mantine/core";
+
+export const useLoginContainerStyles = createStyles((theme) => ({
+  text: {
+    color: theme.colors.green[7],
+    textAlign: "center",
+    marginTop: 24,
+    cursor: "pointer",
+  },
+}));

--- a/modules/Login/containers/LoginContainer.tsx
+++ b/modules/Login/containers/LoginContainer.tsx
@@ -4,16 +4,25 @@ import { Anchor, Flex, Text } from "@mantine/core";
 import { useDisclosure } from "@mantine/hooks";
 
 import ChooseRole from "@/modules/HomePage/components/ChooseRole/ChooseRole";
+import ForgetPassword from "@/modules/ResetPassword/containers/ForgetPassword/ForgetPassword";
 
 import LoginForm from "../components/LoginForm";
+import { useLoginContainerStyles } from "./LoginContainer.styles";
 
 const LoginContainer = () => {
   const [opened, { open, close }] = useDisclosure(false);
+  const { classes } = useLoginContainerStyles();
+
+  const [
+    forgetPasswordModalOpenend,
+    { open: openForgetPasswordModal, close: closeForgetPasswordModal },
+  ] = useDisclosure(false);
+
   return (
     <>
       <Flex justify={"center"} align={"center"} mih={"100vh"} direction={"column"}>
         <LoginForm />
-        <Text fw={400} ta="center" my="xs" size="md" c="green">
+        <Text className={classes.text} onClick={openForgetPasswordModal}>
           Forgot Password?
         </Text>
 
@@ -24,7 +33,7 @@ const LoginContainer = () => {
           </Anchor>
         </Text>
       </Flex>
-
+      <ForgetPassword opened={forgetPasswordModalOpenend} close={closeForgetPasswordModal} />
       <ChooseRole opened={opened} close={close} />
     </>
   );

--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.schema.ts
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.schema.ts
@@ -1,0 +1,14 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const updatePasswordFormSchema = z
+  .object({
+    newPassword: z.string().trim().min(6, "Password must be at least 6 characters"),
+    confirmPassword: z.string().trim().min(6, "Confirm Password is required"),
+  })
+  .refine((data) => data.newPassword === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ["confirmPassword"],
+  });
+
+export const updatePasswordFormSchemaResolver = zodResolver(updatePasswordFormSchema);

--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.tsx
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.tsx
@@ -1,0 +1,77 @@
+import { Button, Flex, PasswordInput } from "@mantine/core";
+import { Controller, useForm } from "react-hook-form";
+
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import { updatePasswordFormSchemaResolver } from "./UpdatePasswordForm.schema";
+import { TUpdatePasswordFormData, TUpdatePasswordFormProps } from "./UpdatePasswordForm.types";
+
+const UpdatePasswordForm = ({ close, setRenderingType }: TUpdatePasswordFormProps) => {
+  const {
+    control,
+    reset,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<TUpdatePasswordFormData>({
+    mode: "onSubmit",
+    resolver: updatePasswordFormSchemaResolver,
+  });
+
+  const { classes } = useForgetPasswordStyles();
+
+  const handleOnSubmit = (data: TUpdatePasswordFormData) => {
+    // Add api call method
+    console.log(data);
+    close();
+    setRenderingType(ERenderFieldType.EMAIL);
+  };
+
+  const handleCancelButton = () => {
+    reset();
+    close();
+    setRenderingType(ERenderFieldType.EMAIL);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleOnSubmit)}>
+      <Controller
+        name="newPassword"
+        control={control}
+        render={({ field }) => (
+          <PasswordInput
+            {...field}
+            label="New Password"
+            placeholder="Enter your password"
+            error={errors.newPassword?.message}
+            className={classes.input}
+            withAsterisk
+          />
+        )}
+      />
+      <Controller
+        name="confirmPassword"
+        control={control}
+        render={({ field }) => (
+          <PasswordInput
+            {...field}
+            label="Confirm Password"
+            placeholder="Confirm password"
+            error={errors.confirmPassword?.message}
+            className={classes.input}
+            withAsterisk
+          />
+        )}
+      />
+      <Flex justify={"end"} align={"center"} gap={12} mb={10}>
+        <Button bg={"green"} onClick={handleCancelButton}>
+          Cancel
+        </Button>
+        <Button bg={"green"} type="submit">
+          Submit
+        </Button>
+      </Flex>
+    </form>
+  );
+};
+
+export default UpdatePasswordForm;

--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.types.ts
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.types.ts
@@ -1,0 +1,11 @@
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+
+export type TUpdatePasswordFormProps = {
+  close: () => void;
+  setRenderingType: (value: ERenderFieldType) => void;
+};
+
+export type TUpdatePasswordFormData = {
+  newPassword: string;
+  confirmPassword: string;
+};

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.schema.ts
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.schema.ts
@@ -1,0 +1,8 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const verifyEmailFormSchema = z.object({
+  email: z.string().trim().email("Invalid email address"),
+});
+
+export const verifyEmailFormSchemaResolver = zodResolver(verifyEmailFormSchema);

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.tsx
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.tsx
@@ -1,0 +1,63 @@
+import { Button, Flex, TextInput } from "@mantine/core";
+import { Controller, useForm } from "react-hook-form";
+
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import { verifyEmailFormSchemaResolver } from "./VerifyEmailForm.schema";
+import { TVerifyEmailForm, TVerifyEmailFormProps } from "./VerifyEmailForm.types";
+
+const VerifyEmailForm = ({ close, setRenderingType }: TVerifyEmailFormProps) => {
+  const {
+    control,
+    setValue,
+    reset,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<TVerifyEmailForm>({
+    mode: "onSubmit",
+    resolver: verifyEmailFormSchemaResolver,
+  });
+
+  const { classes } = useForgetPasswordStyles();
+
+  const handleOnSubmit = (data: TVerifyEmailForm) => {
+    // Add api call method
+    console.log(data);
+    setRenderingType(ERenderFieldType.OTP);
+  };
+
+  const handleCancelButton = () => {
+    setValue("email", "");
+    reset();
+    close();
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleOnSubmit)}>
+      <Controller
+        name="email"
+        control={control}
+        render={({ field }) => (
+          <TextInput
+            {...field}
+            label="Email"
+            placeholder="Enter your email"
+            error={errors.email?.message}
+            withAsterisk
+            className={classes.input}
+          />
+        )}
+      />
+      <Flex justify={"end"} align={"center"} gap={12} mb={10}>
+        <Button bg={"green"} onClick={handleCancelButton}>
+          Cancel
+        </Button>
+        <Button bg={"green"} type="submit">
+          Submit
+        </Button>
+      </Flex>
+    </form>
+  );
+};
+
+export default VerifyEmailForm;

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.types.ts
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.types.ts
@@ -1,0 +1,10 @@
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+
+export type TVerifyEmailFormProps = {
+  close: () => void;
+  setRenderingType: (value: ERenderFieldType) => void;
+};
+
+export type TVerifyEmailForm = {
+  email: string;
+};

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.schema.ts
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.schema.ts
@@ -1,0 +1,8 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+
+const verifyOtpSchema = z.object({
+  otp: z.string().trim().length(6, "OTP length should be 6"),
+});
+
+export const verifyOtpSchemaResolver = zodResolver(verifyOtpSchema);

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.tsx
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.tsx
@@ -1,0 +1,61 @@
+import { Button, Flex, TextInput } from "@mantine/core";
+import { Controller, useForm } from "react-hook-form";
+
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import { verifyOtpSchemaResolver } from "./VerifyOtpForm.schema";
+import { TVerifyOtpForm, TVerifyOtpFormProps } from "./VerifyOtpForm.types";
+
+const VerifyOtpForm = ({ setRenderingType }: TVerifyOtpFormProps) => {
+  const {
+    control,
+    setValue,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<TVerifyOtpForm>({
+    mode: "onSubmit",
+    resolver: verifyOtpSchemaResolver,
+  });
+
+  const { classes } = useForgetPasswordStyles();
+
+  const handleOnSubmit = (data: TVerifyOtpForm) => {
+    // Add api call method
+    console.log(data);
+    setRenderingType(ERenderFieldType.PASSWORD);
+  };
+
+  const handleBackButton = () => {
+    setValue("otp", "");
+    setRenderingType(ERenderFieldType.EMAIL);
+  };
+
+  return (
+    <form onSubmit={handleSubmit(handleOnSubmit)}>
+      <Controller
+        name="otp"
+        control={control}
+        render={({ field }) => (
+          <TextInput
+            {...field}
+            label="OTP"
+            placeholder="Enter the otp"
+            error={errors.otp?.message}
+            withAsterisk
+            className={classes.input}
+          />
+        )}
+      />
+      <Flex justify={"end"} align={"center"} gap={12} mb={10}>
+        <Button bg={"green"} onClick={handleBackButton}>
+          Back
+        </Button>
+        <Button bg={"green"} type="submit">
+          Submit
+        </Button>
+      </Flex>
+    </form>
+  );
+};
+
+export default VerifyOtpForm;

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.types.ts
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.types.ts
@@ -1,0 +1,9 @@
+import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
+
+export type TVerifyOtpFormProps = {
+  setRenderingType: (value: ERenderFieldType) => void;
+};
+
+export type TVerifyOtpForm = {
+  otp: string;
+};

--- a/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.enums.ts
+++ b/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.enums.ts
@@ -1,0 +1,5 @@
+export enum ERenderFieldType {
+  EMAIL = "EMAIL",
+  OTP = "OTP",
+  PASSWORD = "PASSWORD",
+}

--- a/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.styles.ts
+++ b/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.styles.ts
@@ -1,0 +1,15 @@
+import { createStyles } from "@mantine/core";
+
+export const useForgetPasswordStyles = createStyles((theme) => ({
+  titleText: {
+    textTransform: "uppercase",
+    color: theme.colors.green[6],
+    marginBottom: 20,
+  },
+  input: {
+    label: {
+      color: theme.colors.green[6],
+    },
+    marginBottom: 16,
+  },
+}));

--- a/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.tsx
+++ b/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.tsx
@@ -1,0 +1,34 @@
+import { useState } from "react";
+
+import { Modal, Title } from "@mantine/core";
+
+import UpdatePasswordForm from "../../components/UpdatePasswordForm/UpdatePasswordForm";
+import VerifyEmailForm from "../../components/VerifyEmailForm/VerifyEmailForm";
+import VerifyOtpForm from "../../components/VerifyOtpForm/VerifyOtpForm";
+import { ERenderFieldType } from "./ForgetPassword.enums";
+import { useForgetPasswordStyles } from "./ForgetPassword.styles";
+import { TForgetPasswordProps } from "./ForgetPassword.types";
+
+const ForgetPassword = ({ opened, close }: TForgetPasswordProps) => {
+  const { classes } = useForgetPasswordStyles();
+  const [renderingField, setRenderingType] = useState(ERenderFieldType.EMAIL);
+
+  return (
+    <Modal opened={opened} onClose={close} centered>
+      <Title className={classes.titleText} order={4}>
+        Forget Password
+      </Title>
+      {renderingField === ERenderFieldType.EMAIL ? (
+        <VerifyEmailForm close={close} setRenderingType={setRenderingType} />
+      ) : null}
+      {renderingField === ERenderFieldType.OTP ? (
+        <VerifyOtpForm setRenderingType={setRenderingType} />
+      ) : null}
+      {renderingField === ERenderFieldType.PASSWORD ? (
+        <UpdatePasswordForm close={close} setRenderingType={setRenderingType} />
+      ) : null}
+    </Modal>
+  );
+};
+
+export default ForgetPassword;

--- a/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.types.ts
+++ b/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.types.ts
@@ -1,0 +1,4 @@
+export type TForgetPasswordProps = {
+  opened: boolean;
+  close: () => void;
+};


### PR DESCRIPTION
## Description of Change

- Added Forget Password forms for email and otp verification
- Added Update password form
- Integrated inside ForgetPassword modal

## Associated Ticket Link(s)

- https://trello.com/c/iUSiBZQt

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/fdeb4a06-0dba-4783-86e0-399feb2ef402

