### PR TITLE
feat(ST-152): integrate forget passwrod api mutations

### DIFF
--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.hooks.ts
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.hooks.ts
@@ -1,0 +1,44 @@
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useUpdatePasswordMutation } from "@/shared/redux/rtk-apis/users/users.api";
+import { TUpdatePasswordDto } from "@/shared/redux/rtk-apis/users/users.types";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { TUpdatePasswordFormData } from "./UpdatePasswordForm.types";
+
+const useUpdatePasswordForm = () => {
+  const [updatePassword, { isLoading }] = useUpdatePasswordMutation();
+
+  const onSubmit = async (data: TUpdatePasswordFormData, email: string, otp: string) => {
+    const updatePasswordDto: TUpdatePasswordDto = {
+      email: email,
+      newPassword: data.newPassword,
+      otp,
+    };
+
+    try {
+      await updatePassword(updatePasswordDto).unwrap();
+
+      showNotification({
+        title: "Success",
+        message: "Password updated successfully",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+
+  return { onSubmit, isLoading };
+};
+
+export default useUpdatePasswordForm;

--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.tsx
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.tsx
@@ -3,10 +3,11 @@ import { Controller, useForm } from "react-hook-form";
 
 import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
 import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import useUpdatePasswordForm from "./UpdatePasswordForm.hooks";
 import { updatePasswordFormSchemaResolver } from "./UpdatePasswordForm.schema";
 import { TUpdatePasswordFormData, TUpdatePasswordFormProps } from "./UpdatePasswordForm.types";
 
-const UpdatePasswordForm = ({ close, setRenderingType }: TUpdatePasswordFormProps) => {
+const UpdatePasswordForm = ({ close, setRenderingType, email, otp }: TUpdatePasswordFormProps) => {
   const {
     control,
     reset,
@@ -19,11 +20,14 @@ const UpdatePasswordForm = ({ close, setRenderingType }: TUpdatePasswordFormProp
 
   const { classes } = useForgetPasswordStyles();
 
+  const { onSubmit, isLoading } = useUpdatePasswordForm();
+
   const handleOnSubmit = (data: TUpdatePasswordFormData) => {
-    // Add api call method
-    console.log(data);
-    close();
-    setRenderingType(ERenderFieldType.EMAIL);
+    onSubmit(data, email, otp);
+    if (!isLoading) {
+      close();
+      setRenderingType(ERenderFieldType.EMAIL);
+    }
   };
 
   const handleCancelButton = () => {
@@ -66,7 +70,7 @@ const UpdatePasswordForm = ({ close, setRenderingType }: TUpdatePasswordFormProp
         <Button bg={"green"} onClick={handleCancelButton}>
           Cancel
         </Button>
-        <Button bg={"green"} type="submit">
+        <Button loading={isLoading} bg={"green"} type="submit">
           Submit
         </Button>
       </Flex>

--- a/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.types.ts
+++ b/modules/ResetPassword/components/UpdatePasswordForm/UpdatePasswordForm.types.ts
@@ -3,6 +3,8 @@ import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword
 export type TUpdatePasswordFormProps = {
   close: () => void;
   setRenderingType: (value: ERenderFieldType) => void;
+  email: string;
+  otp: string;
 };
 
 export type TUpdatePasswordFormData = {

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.hooks.ts
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.hooks.ts
@@ -1,0 +1,42 @@
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useVerifyEmailMutation } from "@/shared/redux/rtk-apis/verify-users/verify-users.api";
+import { TVerifyEmailDto } from "@/shared/redux/rtk-apis/verify-users/verify-users.types";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { TVerifyEmailForm } from "./VerifyEmailForm.types";
+
+const useVerifyEmailForm = () => {
+  const [verifyEmail, { isLoading }] = useVerifyEmailMutation();
+
+  const onSubmit = async (data: TVerifyEmailForm) => {
+    const verifyEmailDto: TVerifyEmailDto = {
+      email: data.email,
+    };
+
+    try {
+      await verifyEmail(verifyEmailDto).unwrap();
+
+      showNotification({
+        title: "Success",
+        message: "OTP is sent to this email",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+
+  return { onSubmit, isLoading };
+};
+
+export default useVerifyEmailForm;

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.tsx
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.tsx
@@ -3,10 +3,11 @@ import { Controller, useForm } from "react-hook-form";
 
 import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
 import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import useVerifyEmailForm from "./VerifyEmailForm.hooks";
 import { verifyEmailFormSchemaResolver } from "./VerifyEmailForm.schema";
 import { TVerifyEmailForm, TVerifyEmailFormProps } from "./VerifyEmailForm.types";
 
-const VerifyEmailForm = ({ close, setRenderingType }: TVerifyEmailFormProps) => {
+const VerifyEmailForm = ({ close, setRenderingType, setEmail }: TVerifyEmailFormProps) => {
   const {
     control,
     setValue,
@@ -19,15 +20,19 @@ const VerifyEmailForm = ({ close, setRenderingType }: TVerifyEmailFormProps) => 
   });
 
   const { classes } = useForgetPasswordStyles();
+  const { onSubmit, isLoading } = useVerifyEmailForm();
 
   const handleOnSubmit = (data: TVerifyEmailForm) => {
-    // Add api call method
-    console.log(data);
-    setRenderingType(ERenderFieldType.OTP);
+    onSubmit(data);
+    if (!isLoading) {
+      setEmail(data.email);
+      setRenderingType(ERenderFieldType.OTP);
+    }
   };
 
   const handleCancelButton = () => {
     setValue("email", "");
+    setEmail("");
     reset();
     close();
   };
@@ -52,7 +57,7 @@ const VerifyEmailForm = ({ close, setRenderingType }: TVerifyEmailFormProps) => 
         <Button bg={"green"} onClick={handleCancelButton}>
           Cancel
         </Button>
-        <Button bg={"green"} type="submit">
+        <Button loading={isLoading} bg={"green"} type="submit">
           Submit
         </Button>
       </Flex>

--- a/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.types.ts
+++ b/modules/ResetPassword/components/VerifyEmailForm/VerifyEmailForm.types.ts
@@ -3,6 +3,7 @@ import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword
 export type TVerifyEmailFormProps = {
   close: () => void;
   setRenderingType: (value: ERenderFieldType) => void;
+  setEmail: (value: string) => void;
 };
 
 export type TVerifyEmailForm = {

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.hooks.ts
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.hooks.ts
@@ -1,0 +1,43 @@
+import { showNotification } from "@mantine/notifications";
+
+import { NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS } from "@/shared/constants/app.constants";
+import { useVerifyOtpMutation } from "@/shared/redux/rtk-apis/verify-users/verify-users.api";
+import { TVerifyOtpDto } from "@/shared/redux/rtk-apis/verify-users/verify-users.types";
+import { parseApiErrorMessage } from "@/shared/utils/errors";
+
+import { TVerifyOtpForm } from "./VerifyOtpForm.types";
+
+const useVerifyOtpForm = () => {
+  const [verifyOtp, { isLoading }] = useVerifyOtpMutation();
+
+  const onSubmit = async (data: TVerifyOtpForm, email: string) => {
+    const verifyOtpDto: TVerifyOtpDto = {
+      otp: data.otp,
+      email,
+    };
+
+    try {
+      await verifyOtp(verifyOtpDto).unwrap();
+
+      showNotification({
+        title: "Success",
+        message: "OTP is verified successfully",
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "green",
+      });
+    } catch (error) {
+      const errorMessage = parseApiErrorMessage(error);
+
+      showNotification({
+        title: "Error",
+        message: errorMessage,
+        autoClose: NOTIFICATION_AUTO_CLOSE_TIMEOUT_IN_MILLISECONDS,
+        color: "red",
+      });
+    }
+  };
+
+  return { onSubmit, isLoading };
+};
+
+export default useVerifyOtpForm;

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.tsx
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.tsx
@@ -3,10 +3,11 @@ import { Controller, useForm } from "react-hook-form";
 
 import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword.enums";
 import { useForgetPasswordStyles } from "../../containers/ForgetPassword/ForgetPassword.styles";
+import useVerifyOtpForm from "./VerifyOtpForm.hooks";
 import { verifyOtpSchemaResolver } from "./VerifyOtpForm.schema";
 import { TVerifyOtpForm, TVerifyOtpFormProps } from "./VerifyOtpForm.types";
 
-const VerifyOtpForm = ({ setRenderingType }: TVerifyOtpFormProps) => {
+const VerifyOtpForm = ({ setRenderingType, email, setOtp }: TVerifyOtpFormProps) => {
   const {
     control,
     setValue,
@@ -19,10 +20,16 @@ const VerifyOtpForm = ({ setRenderingType }: TVerifyOtpFormProps) => {
 
   const { classes } = useForgetPasswordStyles();
 
+  const { onSubmit, isLoading } = useVerifyOtpForm();
+
   const handleOnSubmit = (data: TVerifyOtpForm) => {
-    // Add api call method
-    console.log(data);
-    setRenderingType(ERenderFieldType.PASSWORD);
+    onSubmit(data, email);
+
+    setOtp(data.otp);
+
+    if (!isLoading) {
+      setRenderingType(ERenderFieldType.PASSWORD);
+    }
   };
 
   const handleBackButton = () => {
@@ -50,7 +57,7 @@ const VerifyOtpForm = ({ setRenderingType }: TVerifyOtpFormProps) => {
         <Button bg={"green"} onClick={handleBackButton}>
           Back
         </Button>
-        <Button bg={"green"} type="submit">
+        <Button loading={isLoading} bg={"green"} type="submit">
           Submit
         </Button>
       </Flex>

--- a/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.types.ts
+++ b/modules/ResetPassword/components/VerifyOtpForm/VerifyOtpForm.types.ts
@@ -2,6 +2,8 @@ import { ERenderFieldType } from "../../containers/ForgetPassword/ForgetPassword
 
 export type TVerifyOtpFormProps = {
   setRenderingType: (value: ERenderFieldType) => void;
+  setOtp: (value: string) => void;
+  email: string;
 };
 
 export type TVerifyOtpForm = {

--- a/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.tsx
+++ b/modules/ResetPassword/containers/ForgetPassword/ForgetPassword.tsx
@@ -12,6 +12,8 @@ import { TForgetPasswordProps } from "./ForgetPassword.types";
 const ForgetPassword = ({ opened, close }: TForgetPasswordProps) => {
   const { classes } = useForgetPasswordStyles();
   const [renderingField, setRenderingType] = useState(ERenderFieldType.EMAIL);
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
 
   return (
     <Modal opened={opened} onClose={close} centered>
@@ -19,13 +21,18 @@ const ForgetPassword = ({ opened, close }: TForgetPasswordProps) => {
         Forget Password
       </Title>
       {renderingField === ERenderFieldType.EMAIL ? (
-        <VerifyEmailForm close={close} setRenderingType={setRenderingType} />
+        <VerifyEmailForm close={close} setRenderingType={setRenderingType} setEmail={setEmail} />
       ) : null}
       {renderingField === ERenderFieldType.OTP ? (
-        <VerifyOtpForm setRenderingType={setRenderingType} />
+        <VerifyOtpForm setRenderingType={setRenderingType} setOtp={setOtp} email={email} />
       ) : null}
       {renderingField === ERenderFieldType.PASSWORD ? (
-        <UpdatePasswordForm close={close} setRenderingType={setRenderingType} />
+        <UpdatePasswordForm
+          close={close}
+          setRenderingType={setRenderingType}
+          email={email}
+          otp={otp}
+        />
       ) : null}
     </Modal>
   );

--- a/shared/redux/rtk-apis/users/users.api.ts
+++ b/shared/redux/rtk-apis/users/users.api.ts
@@ -2,7 +2,12 @@ import { IUserDto, TApiResponse } from "@/shared/typedefs";
 
 import projectApi from "../api.config";
 import { TLoginResponse, TTokenizedUser } from "../auth/auth.types";
-import { TUpdateUserDto, TUser } from "./users.types";
+import {
+  TUpdateUserDto,
+  TUpdatePasswordApiResponse,
+  TUpdatePasswordDto,
+  TUser,
+} from "./users.types";
 
 const usersApi = projectApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -40,6 +45,14 @@ const usersApi = projectApi.injectEndpoints({
       invalidatesTags: ["UsersProfile"],
       transformResponse: (response: TApiResponse<TTokenizedUser>) => response.data,
     }),
+
+    updatePassword: builder.mutation<TUpdatePasswordApiResponse, TUpdatePasswordDto>({
+      query: (updatePasswordDto) => ({
+        url: "users/update-password",
+        method: "PATCH",
+        body: updatePasswordDto,
+      }),
+    }),
   }),
   overrideExisting: false,
 });
@@ -51,4 +64,5 @@ export const {
   useGetStudentsQuery,
   useGetUserProfileQuery,
   useUpdateUserMutation,
+  useUpdatePasswordMutation,
 } = usersApi;

--- a/shared/redux/rtk-apis/users/users.types.ts
+++ b/shared/redux/rtk-apis/users/users.types.ts
@@ -65,3 +65,15 @@ export type TUpdateUserDto = {
   teacherInput?: TTeacher;
   studentInput?: TUpdateStudentDto;
 };
+
+export type TUpdatePasswordDto = {
+  email: string;
+  otp: string;
+  newPassword: string;
+};
+
+export type TUpdatePasswordApiResponse = {
+  status: number;
+  message: string;
+  data: string;
+};

--- a/shared/redux/rtk-apis/verify-users/verify-users.api.ts
+++ b/shared/redux/rtk-apis/verify-users/verify-users.api.ts
@@ -1,0 +1,23 @@
+import projectApi from "../api.config";
+import { TVerificationResponse, TVerifyEmailDto, TVerifyOtpDto } from "./verify-users.types";
+
+const verifyUsersApi = projectApi.injectEndpoints({
+  endpoints: (builder) => ({
+    verifyEmail: builder.mutation<TVerificationResponse, TVerifyEmailDto>({
+      query: (verifyEmailDto) => ({
+        url: "verify-users/email",
+        method: "POST",
+        body: verifyEmailDto,
+      }),
+    }),
+    verifyOtp: builder.mutation<TVerificationResponse, TVerifyOtpDto>({
+      query: (verifyOtpDto) => ({
+        url: "verify-users/otp",
+        method: "POST",
+        body: verifyOtpDto,
+      }),
+    }),
+  }),
+});
+
+export const { useVerifyEmailMutation, useVerifyOtpMutation } = verifyUsersApi;

--- a/shared/redux/rtk-apis/verify-users/verify-users.types.ts
+++ b/shared/redux/rtk-apis/verify-users/verify-users.types.ts
@@ -1,0 +1,14 @@
+export type TVerificationResponse = {
+  status: number;
+  message: string;
+  data: string;
+};
+
+export type TVerifyEmailDto = {
+  email: string;
+};
+
+export type TVerifyOtpDto = {
+  otp: string;
+  email: string;
+};


### PR DESCRIPTION
## Description of Change

- Added three mutations for verify email & otp and one for updating password
- Added corresponding hooks
- Integrated form submissions with api inside the hook

## Associated Ticket Link(s)

- https://trello.com/c/jW5IK8nc

## Related Pull Request(s)

- N/A

## Screenshots / Screen Recordings

https://github.com/user-attachments/assets/01d74729-e8bd-4605-8c25-5468649a811f

